### PR TITLE
Added support for Saml ArtifactResolution

### DIFF
--- a/ITfoxtec.Saml2/ArtifactResolve.cs
+++ b/ITfoxtec.Saml2/ArtifactResolve.cs
@@ -1,0 +1,80 @@
+﻿using ITfoxtec.Saml2.Schemas;
+using ITfoxtec.Saml2.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace ITfoxtec.Saml2
+{
+    public class ArtifactResolve : Saml2Request
+    {
+        const string elementName = Saml2Constants.Message.ArtifactResolve;
+
+        public X509Certificate2 SigningCertificate { get; set; }
+        public string Artifact { get; set; }
+
+        public ArtifactResolve(X509Certificate2 signingCertificate = null)
+        {
+            this.SigningCertificate = signingCertificate;
+        }
+
+        public override XmlDocument ToXml()
+        {
+            var envelope = new XElement(Saml2Constants.ProtocolNamespaceX + elementName);
+
+            envelope.Add(base.GetXContent());
+            envelope.Add(GetXContent());
+
+            XmlDocument = envelope.ToXmlDocument();
+            if (SigningCertificate != null)
+                XmlDocument = XmlDocument.SignDocument(SigningCertificate, X509IncludeOption.EndCertOnly, Id.Value, removeKeyInfo: true);
+            return XmlDocument;
+        }
+
+        protected override IEnumerable<XObject> GetXContent()
+        {
+
+            yield return new XElement(Saml2Constants.ProtocolNamespaceX + Saml2Constants.Message.Artifact, Artifact);
+        }
+
+        protected override void ValidateElementName()
+        {
+            if (XmlDocument.DocumentElement.LocalName != elementName)
+            {
+                throw new Saml2ResponseException("Not a SAML2 Artifact Resolve Request.");
+            }
+        }
+
+        public void Resolve(IdpSsoService artifactResolutionService, Saml2AuthnResponse authnResponse)
+        {
+            var xmlDoc = this.ToXml();
+
+            var soapEnvelope = new SOAPEnvelope();
+            soapEnvelope.Body = xmlDoc;
+
+            xmlDoc = soapEnvelope.ToSoapXml();
+            WebClient client = new WebClient();
+            client.Encoding = Encoding.UTF8;
+            client.Headers.Add(HttpRequestHeader.ContentType, "text/xml; charset=\"utf-8\"");
+            client.Headers.Add(HttpRequestHeader.Accept, "text/xml");
+            var result = client.UploadString(artifactResolutionService.Location, xmlDoc.OuterXml);
+
+            soapEnvelope.FromSoapXml(result);
+
+            var ares = new SamlArtifactResponse(authnResponse)
+            {
+                SignatureValidationCertificate = SignatureValidationCertificate
+            };
+            ares.Read(soapEnvelope.Body.OuterXml, SignatureValidationCertificate != null);
+
+
+        }
+
+    }
+}

--- a/ITfoxtec.Saml2/Bindings/ArtifactBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/ArtifactBinding.cs
@@ -1,0 +1,56 @@
+﻿using ITfoxtec.Saml2.Schemas;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace ITfoxtec.Saml2.Bindings
+{
+    public class ArtifactBinding : Saml2Binding
+    {
+        /// <summary>
+        /// [Optional]
+        /// Default EndCertOnly (Only the end certificate is included in the X.509 chain information).
+        /// </summary>
+        public X509IncludeOption CertificateIncludeOption { get; set; }
+
+        /// <summary>
+        /// Html post content.
+        /// </summary>
+        public string SAMLart { get; set; }
+
+        public ArtifactBinding()
+        {
+            CertificateIncludeOption = X509IncludeOption.EndCertOnly;
+        }
+
+
+        public Saml2Request Unbind(HttpRequestBase request, ArtifactResolve saml2Request, X509Certificate2 signatureValidationCertificate)
+        {
+            return UnbindInternal(request, saml2Request, Saml2Constants.Message.SamlArt, signatureValidationCertificate);
+        }
+
+        protected Saml2Request UnbindInternal(HttpRequestBase request, ArtifactResolve saml2RequestResponse, string messageName, X509Certificate2 signatureValidationCertificate)
+        {
+            base.UnbindInternal(request, saml2RequestResponse, signatureValidationCertificate);
+
+            if (!"GET".Equals(request.HttpMethod, StringComparison.InvariantCultureIgnoreCase))
+                throw new InvalidSaml2BindingException("Not HTTP POST Method.");
+
+            if (!request.QueryString.AllKeys.Contains(messageName))
+                throw new Saml2BindingException("QueryString does not contain " + messageName);
+
+            if (request.QueryString.AllKeys.Contains(Saml2Constants.Message.RelayState))
+            {
+                RelayState = request.QueryString[Saml2Constants.Message.RelayState];
+            }
+
+            saml2RequestResponse.Artifact = request.QueryString[messageName];
+
+            return saml2RequestResponse;
+        }
+    }
+}

--- a/ITfoxtec.Saml2/Extensions/XmlDocumentExtensions.cs
+++ b/ITfoxtec.Saml2/Extensions/XmlDocumentExtensions.cs
@@ -18,17 +18,20 @@ namespace ITfoxtec.Saml2
         /// <param name="certificate">The certificate used to sign the document</param>
         /// <param name="includeOption">Certificate include option</param>
         /// <param name="id">The is of the topmost element in the xmldocument</param>
-        internal static XmlDocument SignDocument(this XmlDocument xmlDocument, X509Certificate2 certificate, X509IncludeOption includeOption, string id)
+        /// <param name="removeKeyInfo">Set to true if key info should be removed from the signature.</param>
+        public static XmlDocument SignDocument(this XmlDocument xmlDocument, X509Certificate2 certificate, X509IncludeOption includeOption, string id, bool removeKeyInfo = false)
         {
             if (certificate == null)
             {
                 throw new ArgumentNullException("certificate");
             }
- 
+
             var signedXml = new Saml2SignedXml(xmlDocument);
             signedXml.ComputeSignature(certificate, includeOption, id);
 
             var issuer = xmlDocument.DocumentElement[Saml2Constants.Message.Issuer, Saml2Constants.AssertionNamespace.OriginalString];
+            if (removeKeyInfo)
+                signedXml.KeyInfo = null;
             xmlDocument.DocumentElement.InsertAfter(xmlDocument.ImportNode(signedXml.GetXml(), true), issuer);
             return xmlDocument;
         }

--- a/ITfoxtec.Saml2/ITfoxtec.Saml2.csproj
+++ b/ITfoxtec.Saml2/ITfoxtec.Saml2.csproj
@@ -56,6 +56,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArtifactResolve.cs" />
+    <Compile Include="Bindings\ArtifactBinding.cs" />
     <Compile Include="Bindings\InvalidSaml2BindingException.cs" />
     <Compile Include="Bindings\Saml2Binding.cs" />
     <Compile Include="Bindings\Saml2BindingException.cs" />
@@ -84,6 +86,7 @@
     <Compile Include="Saml2Request.cs" />
     <Compile Include="Saml2Response.cs" />
     <Compile Include="Saml2ResponseException.cs" />
+    <Compile Include="SamlArtifactResponse.cs" />
     <Compile Include="Schemas\AuthnContextClassTypes.cs" />
     <Compile Include="Schemas\AuthnContextComparisonTypes.cs" />
     <Compile Include="Schemas\ConsentIdentifierTypes.cs" />
@@ -107,10 +110,12 @@
     <Compile Include="Tokens\Saml2ResponseIssuerNameRegistry.cs" />
     <Compile Include="Tokens\Saml2ResponseSecurityTokenHandler.cs" />
     <Compile Include="Util\CertificateUtil.cs" />
+    <Compile Include="Util\IdpSsoService.cs" />
     <Compile Include="Util\RawSaml2QueryString.cs" />
     <Compile Include="Schemas\Saml2Constants.cs" />
     <Compile Include="Schemas\Saml2StatusCodes.cs" />
     <Compile Include="Util\Saml2StatusCodeUtil.cs" />
+    <Compile Include="Util\SoapEnvelope.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ITfoxtec.Saml2/SamlArtifactResponse.cs
+++ b/ITfoxtec.Saml2/SamlArtifactResponse.cs
@@ -1,0 +1,63 @@
+﻿using ITfoxtec.Saml2.Schemas;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace ITfoxtec.Saml2
+{
+    public class SamlArtifactResponse : Saml2Response
+    {
+        const string elementName = Saml2Constants.Message.ArtifactResponse;
+        internal X509Certificate2 DecryptionCertificate { get; private set; }
+
+        public Saml2AuthnResponse AuthnResponse { get; set; }
+        public SamlArtifactResponse(Saml2AuthnResponse response)
+        {
+            AuthnResponse = response;
+        }
+
+        protected override void DecryptMessage()
+        {
+
+        }
+
+        internal override void Read(string xml, bool validateXmlSignature = false)
+        {
+            base.Read(xml, false);
+
+            if (Status == Saml2StatusCodes.Success)
+            {
+                var authnReponse = GetAuthnReponse();
+                AuthnResponse.Read(authnReponse.OuterXml, SignatureValidationCertificate != null && validateXmlSignature);
+            }
+        }
+
+        private XmlNode GetAuthnReponse()
+        {
+            var assertionElements = XmlDocument.DocumentElement.SelectNodes(string.Format("//*[local-name()='{0}']", Saml2Constants.Message.AuthnResponse));
+            if (assertionElements.Count != 1)
+            {
+                throw new Saml2ResponseException("There is not exactly one Assertion element.");
+            }
+            return assertionElements[0];
+        }
+
+
+        public override System.Xml.XmlDocument ToXml()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void ValidateElementName()
+        {
+            if (XmlDocument.DocumentElement.LocalName != elementName)
+            {
+                throw new Saml2ResponseException("Not a SAML2 Artifact Response.");
+            }
+        }
+    }
+}

--- a/ITfoxtec.Saml2/Schemas/Saml2Constants.cs
+++ b/ITfoxtec.Saml2/Schemas/Saml2Constants.cs
@@ -47,6 +47,8 @@ namespace ITfoxtec.Saml2.Schemas
 
             public const string SamlRequest = "SAMLRequest";
 
+            public const string ArtifactResolve = "ArtifactResolve";
+
             public const string RelayState = "RelayState";
 
             public const string Assertion = "Assertion";
@@ -122,8 +124,14 @@ namespace ITfoxtec.Saml2.Schemas
             public const string Subject = "Subject";
 
             public const string SubjectConfirmation = "SubjectConfirmation";
-            
+
             public const string SubjectConfirmationData = "SubjectConfirmationData";
+
+            public const string Artifact = "Artifact";
+
+            public const string SamlArt = "SAMLart";
+            
+            public const string ArtifactResponse = "ArtifactResponse";
         }
     
     }

--- a/ITfoxtec.Saml2/Util/IdpSsoService.cs
+++ b/ITfoxtec.Saml2/Util/IdpSsoService.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ITfoxtec.Saml2.Util
+{
+    public class IdpSsoService
+    {
+        public string Binding { get; set; }
+        public string Location { get; set; }
+        public int Index { get; set; }
+        public bool IsDefault { get; set; }
+
+        public IdpSsoService(string binding, string location, int index, bool isDefault)
+        {
+            Binding = binding;
+            Location = location;
+            Index = index;
+            IsDefault = isDefault;
+        }
+
+        public static class Constants
+        {
+            public const string SingleLogoutServiceTag = "SingleLogoutService";
+            public const string SingleSignOnServiceTag = "SingleSignOnService";
+            public const string ArtifactResolutionServiceTag = "ArtifactResolutionService";
+
+            public const string BindingAttribute = "Binding";
+            public const string LocationAttribute = "Location";
+            public const string IndexAttribute = "index";
+            public const string IsDefaultAttribute = "isDefault";
+            public const string NameIDFormatTag = "NameIDFormat";
+
+
+        }
+    }
+}

--- a/ITfoxtec.Saml2/Util/SoapEnvelope.cs
+++ b/ITfoxtec.Saml2/Util/SoapEnvelope.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace ITfoxtec.Saml2.Util
+{
+    public class SOAPEnvelope
+    {
+        public XmlDocument Body { get; set; }
+
+        public XmlDocument ToSoapXml()
+        {
+            var envelope = new XElement(Constants.SoapEnvironmentNamespaceX + Constants.Envelope);
+
+            envelope.Add(GetXContent());
+
+            XmlDocument xmldoc = envelope.ToXmlDocument();
+            return xmldoc;
+        }
+
+        public void FromSoapXml(string xml)
+        {
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(xml);
+
+            var bodyList = GetNodesByLocalname(xmlDoc.DocumentElement, "Body");
+            if (bodyList.Count != 1)
+            {
+                throw new Exception("There is not exactly one Body element.");
+            }
+            xmlDoc.LoadXml(bodyList[0].InnerXml);
+            Body = xmlDoc;
+            var faultBody = GetNodeByLocalname(bodyList[0], "Fault");
+            if (faultBody != null)
+            {
+                var faultcode = GetNodeByLocalname(faultBody, "faultcode");
+                var faultstring = GetNodeByLocalname(faultBody, "faultstring");
+                throw new Saml2ResponseException("Soap Error: " + faultcode + "\n" + faultstring);
+            }
+        }
+
+
+        private XmlNodeList GetNodesByLocalname(XmlNode xe, string localName)
+        {
+            return xe.SelectNodes(string.Format("//*[local-name()='{0}']", localName));
+        }
+
+        private XmlNode GetNodeByLocalname(XmlNode xe, string localName)
+        {
+            return xe.SelectSingleNode(string.Format("//*[local-name()='{0}']", localName));
+        }
+
+
+        protected IEnumerable<XObject> GetXContent()
+        {
+            yield return new XAttribute(Constants.SoapEnvironmentNamespaceName, Constants.SoapEnvironmentNamespace.OriginalString);
+            XDocument xBody = XDocument.Load(new XmlNodeReader(Body));
+            var bodyElement = new XElement(Constants.SoapEnvironmentNamespaceX + Constants.Body, xBody.Root);
+            yield return bodyElement;
+        }
+
+        private static class Constants
+        {
+            public static readonly Uri SoapEnvironmentNamespace = new Uri("http://schemas.xmlsoap.org/soap/envelope/");
+            public static readonly XNamespace SoapEnvironmentNamespaceX = XNamespace.Get(SoapEnvironmentNamespace.OriginalString);
+            public static readonly XName SoapEnvironmentNamespaceName = XNamespace.Xmlns + "SOAP-ENV";
+            public const string Envelope = "Envelope";
+            public const string Body = "Body";
+        }
+    }
+}


### PR DESCRIPTION
Added support for Saml ArtifactResolution. This is tested against DIFI
in norway, for their ID-Porten solution.

The ArtifactResolution part added in this commit, is built to support the same use of binding as with a standard postbinding.

The main difference is that you have to return a call to the IdP's ArtifactResolution Service, to retrieve the identity.

**Default Assertion**

```
public ActionResult AssertionConsumerService()
{
    var binding = new Saml2PostBinding();
    var saml2AuthnResponse = new Saml2AuthnResponse();

    binding.Unbind(Request, saml2AuthnResponse, CertificateUtil.Load("~/App_Data/signing-adfs.test_Certificate.crt"));
    saml2AuthnResponse.CreateSession();

    var returnUrl = binding.GetRelayStateQuery()[relayStateReturnUrl];
    return Redirect(string.IsNullOrWhiteSpace(returnUrl) ? Url.Content("~/") : returnUrl);
}
```

**ArtifactResolution AssertionConsumerService**

```
public ActionResult AssertionConsumerService()
{
   var binding = new ArtifactBinding();

   var artifactResolve = new ArtifactResolve(SigningCertificate) {  Issuer = new EndpointReference(SPId) };
   binding.Unbind(Request, artifactResolve, MetaEntityDescriptor.IdPSsoDescriptor.SigningCertificate);
   var saml2AuthnResponse = new Saml2AuthnResponse(DecryptionCertificate) { SignatureValidationCertificate = MetaEntityDescriptor.IdPSsoDescriptor.SigningCertificate };
   // Resolve Identity
   artifactResolve.Resolve(MetaEntityDescriptor.IdPSsoDescriptor.ArtifactResolutionService, saml2AuthnResponse);
   saml2AuthnResponse.CreateSession();

   var returnUrl = binding.GetRelayStateQuery()[relayStateReturnUrl];
   return Redirect(string.IsNullOrWhiteSpace(returnUrl) ? Url.Content("~/") : returnUrl);
}
```
