### PR TITLE
Properly append redirect location query string

### DIFF
--- a/ITfoxtec.Saml2.Mvc/Properties/AssemblyInfo.cs
+++ b/ITfoxtec.Saml2.Mvc/Properties/AssemblyInfo.cs
@@ -3,10 +3,10 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ITfoxtec SAML 2.0 MVC")]
+[assembly: AssemblyTitle("TechSmith ITfoxtec SAML 2.0 MVC")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ITfoxtec")]
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -29,11 +29,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.2.3.0")]
-[assembly: AssemblyFileVersion("1.2.3.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
@@ -5,7 +5,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Web;
-using System.Xml;
 using ITfoxtec.Saml2.Schemas;
 using ITfoxtec.Saml2.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -40,11 +39,17 @@ namespace ITfoxtec.Saml2.Bindings
                 requestQueryString = SigneQueryString(requestQueryString, signingCertificate);
             }
 
-            RedirectLocation = new Uri(string.Join("?", saml2RequestResponse.Destination.Uri.OriginalString, requestQueryString));
-
+            if (string.IsNullOrWhiteSpace(saml2RequestResponse.Destination.Uri.Query))
+            {
+               RedirectLocation = new Uri( saml2RequestResponse.Destination.Uri.OriginalString + "?" + requestQueryString);
+            }
+            else
+            {
+               RedirectLocation = new Uri(saml2RequestResponse.Destination.Uri.OriginalString + "?" + saml2RequestResponse.Destination.Uri.Query + "&" + requestQueryString);
+            }
             return this;
         }
-        
+
         private string SigneQueryString(string queryString, X509Certificate2 signingCertificate)
         {
             var saml2Signed = new Saml2Sign(signingCertificate.PrivateKey);

--- a/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
@@ -63,7 +63,7 @@ namespace ITfoxtec.Saml2.Bindings
             if (!string.IsNullOrWhiteSpace(RelayState))
             {
                 var relayState = HttpUtility.UrlEncode(RelayState);
-                if (relayState != null)
+                if (!string.IsNullOrWhiteSpace(relayState))
                 {
                    queryString.Add(Saml2Constants.Message.RelayState, relayState);
                 }
@@ -72,7 +72,7 @@ namespace ITfoxtec.Saml2.Bindings
             if(signingCertificate != null)
             {
                 var signatureAlgorithm = HttpUtility.UrlEncode(signingCertificate.PrivateKey.SignatureAlgorithm);
-                if (signatureAlgorithm != null)
+                if (!string.IsNullOrWhiteSpace(signatureAlgorithm))
                 {
                    queryString.Add(Saml2Constants.Message.SigAlg, signatureAlgorithm);
                 }

--- a/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
@@ -36,13 +36,8 @@ namespace ITfoxtec.Saml2.Bindings
             var uriBuilder = new UriBuilder(saml2RequestResponse.Destination.Uri.OriginalString);
             NameValueCollection queryString = HttpUtility.ParseQueryString(uriBuilder.Query);
             queryString.Add(RequestQueryString(signingCertificate, messageName));
-
-            if (signingCertificate != null)
-            {
-               queryString.Add(Saml2Constants.Message.Signature, SigneQueryString(queryString.ToString(),signingCertificate));
-            }
-
             uriBuilder.Query = queryString.ToString();
+
             RedirectLocation = uriBuilder.Uri;
             return this;
         }
@@ -81,8 +76,10 @@ namespace ITfoxtec.Saml2.Bindings
                 {
                    queryString.Add(Saml2Constants.Message.SigAlg, signatureAlgorithm);
                 }
+
+                queryString.Add(Saml2Constants.Message.Signature, SigneQueryString(queryString.ToString(),signingCertificate));
             }
-           return queryString;
+            return queryString;
         }
 
         private string CompressRequest()

--- a/ITfoxtec.Saml2/ITfoxtec.Saml2.csproj
+++ b/ITfoxtec.Saml2/ITfoxtec.Saml2.csproj
@@ -112,6 +112,9 @@
     <Compile Include="Schemas\Saml2StatusCodes.cs" />
     <Compile Include="Util\Saml2StatusCodeUtil.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="ITfoxtec.Saml2.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ITfoxtec.Saml2/ITfoxtec.Saml2.nuspec
+++ b/ITfoxtec.Saml2/ITfoxtec.Saml2.nuspec
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>TechSmith.ITfoxtec.Saml2</id>
+        <version>1.0</version>
+        <title>TechSmith ITfoxtec SAML 2.0</title>
+        <authors>ITfoxtec</authors>
+        <owners>ITfoxtec</owners>
+        <licenseUrl>http://www.itfoxtec.com/License/3clauseBSD.htm</licenseUrl>
+        <projectUrl>http://www.itfoxtec.com/saml2</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>The ITfoxtec SAML 2.0 package adds SAML-P support on top of the SAML 2.0 token functionality implemented in the .NET framework.
+Supports: Message signing and validation as well as decryption. Login, logout, single logout and metadata. Both SP Initiated and IdP Initiated sign on. The Danish OIOSAML 2.0 profile and NemLog-in.
+
+Supporting .NET 4.5</description>
+        <copyright>© 2007 - 2014 ITfoxtec</copyright>
+        <language>en-US</language>
+        <tags>SAML SAML2.0 SAML2 SAML-P SAMLP SSO Authentication Metadata OIOSAML NemLog-in</tags>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System.IdentityModel" targetFramework="" />
+            <frameworkAssembly assemblyName="System.ServiceModel" targetFramework="" />
+            <frameworkAssembly assemblyName="System.IdentityModel.Services" targetFramework="" />
+            <frameworkAssembly assemblyName="System.Web" targetFramework="" />
+        </frameworkAssemblies>
+    </metadata>
+</package>

--- a/ITfoxtec.Saml2/Properties/AssemblyInfo.cs
+++ b/ITfoxtec.Saml2/Properties/AssemblyInfo.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ITfoxtec SAML 2.0")]
+[assembly: AssemblyTitle("TechSmith ITfoxtec SAML 2.0")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ITfoxtec")]
@@ -15,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -29,11 +28,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.2.3.0")]
-[assembly: AssemblyFileVersion("1.2.3.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ITfoxtec.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
+++ b/ITfoxtec.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
@@ -55,11 +55,13 @@ namespace ITfoxtec.Saml2.Tokens
                 throw new InvalidDataException("The requered NameID Assertion is null");
             }
             identity.AddClaim(new Claim(Saml2ClaimTypes.NameId, saml2SecurityToken.Assertion.Subject.NameId.Value));
-            if (saml2SecurityToken.Assertion.Subject.NameId.Format == null)
+
+            var nameIdFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+            if (saml2SecurityToken.Assertion.Subject.NameId.Format != null)
             {
-                throw new InvalidDataException("The requered NameID Assertion Format is null");
+                nameIdFormat = saml2SecurityToken.Assertion.Subject.NameId.Format.AbsoluteUri;
             }
-            identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, saml2SecurityToken.Assertion.Subject.NameId.Format.AbsoluteUri));
+            identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, nameIdFormat));
             identity.AddClaim(new Claim(Saml2ClaimTypes.SessionIndex, saml2SecurityToken.Id));
 
             if (Configuration.SaveBootstrapContext)


### PR DESCRIPTION
Currently, `BindInternal` assumes `saml2RequestResponse.Destination.Uri.OriginalString` does not contain a query string. In the case where a query string is already present, `BindInternal` will create a bad URL by improperly constructing the query string. This PR addresses such a possibility by using a `UriBuilder` and `NameValueCollection` to build the `RedirectLocation` and its associated query string.
