### PR TITLE
Default NameIdFormat to unspecified

### DIFF
--- a/ITfoxtec.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
+++ b/ITfoxtec.Saml2/Tokens/Saml2ResponseSecurityTokenHandler.cs
@@ -55,11 +55,13 @@ namespace ITfoxtec.Saml2.Tokens
                 throw new InvalidDataException("The requered NameID Assertion is null");
             }
             identity.AddClaim(new Claim(Saml2ClaimTypes.NameId, saml2SecurityToken.Assertion.Subject.NameId.Value));
-            if (saml2SecurityToken.Assertion.Subject.NameId.Format == null)
+
+            var nameIdFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+            if (saml2SecurityToken.Assertion.Subject.NameId.Format != null)
             {
-                throw new InvalidDataException("The requered NameID Assertion Format is null");
+                nameIdFormat = saml2SecurityToken.Assertion.Subject.NameId.Format.AbsoluteUri;
             }
-            identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, saml2SecurityToken.Assertion.Subject.NameId.Format.AbsoluteUri));
+            identity.AddClaim(new Claim(Saml2ClaimTypes.NameIdFormat, nameIdFormat));
             identity.AddClaim(new Claim(Saml2ClaimTypes.SessionIndex, saml2SecurityToken.Id));
 
             if (Configuration.SaveBootstrapContext)


### PR DESCRIPTION
Name id format is pretty fundamental to SAML2 workflow but rather than
blowing up and throwing an exception we will use a default of
`urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified`. The consequence
of this change is that using the format to build up things like SAML
sign out requests will may not actually provide a format that will be
accepted by the SAML identity provider.

Since the NameID format is optional [SAML2.0-core Section 2.2.2](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf) we are using unspecified as a default [SAML2.0-core Section 8.3.1](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)
