### PR TITLE
Allow for clock slip tolerance in verifying response

### DIFF
--- a/ITfoxtec.Saml2/Bindings/Saml2PostBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/Saml2PostBinding.cs
@@ -19,6 +19,12 @@ namespace ITfoxtec.Saml2.Bindings
         public X509IncludeOption CertificateIncludeOption { get; set; }
 
         /// <summary>
+        /// [Optional]
+        /// Allow for clock slip of this amount (on top of what the IDP already includes in the NotOnOrAfter assertion)
+        /// </summary>
+        public TimeSpan? ClockTolerance { get; set; }
+
+        /// <summary>
         /// Html post content.
         /// </summary>
         public string PostContent { get; set; }
@@ -118,7 +124,7 @@ namespace ITfoxtec.Saml2.Bindings
                 RelayState = request.Form[Saml2Constants.Message.RelayState];
             }
 
-            saml2RequestResponse.Read(Encoding.UTF8.GetString(Convert.FromBase64String(request.Form[messageName])), true);
+            saml2RequestResponse.Read(Encoding.UTF8.GetString(Convert.FromBase64String(request.Form[messageName])), true, clockTolerance: this.ClockTolerance);
             XmlDocument = saml2RequestResponse.XmlDocument;
             return saml2RequestResponse;
         }

--- a/ITfoxtec.Saml2/Saml2AuthnResponse.cs
+++ b/ITfoxtec.Saml2/Saml2AuthnResponse.cs
@@ -122,14 +122,14 @@ namespace ITfoxtec.Saml2
             }
 
             var notOnOrAfter = DateTime.Parse(subjectConfirmationData.Attributes[Saml2Constants.Message.NotOnOrAfter].GetValueOrNull(), CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
-            var now = DateTime.UtcNow;
 
             if (clockTolerance.HasValue)
             {
-                now += clockTolerance.Value;
+                // 'Add' the tolerance to the assertion date
+                notOnOrAfter += clockTolerance.Value;
             }
 
-            if (notOnOrAfter < now)
+            if (notOnOrAfter < DateTime.UtcNow)
             {
                 throw new Saml2ResponseException(string.Format("Assertion has expired. Assertion valid NotOnOrAfter {0}.", notOnOrAfter));
             }

--- a/ITfoxtec.Saml2/Saml2AuthnResponse.cs
+++ b/ITfoxtec.Saml2/Saml2AuthnResponse.cs
@@ -98,7 +98,12 @@ namespace ITfoxtec.Saml2
             return assertionElements[0];
         }
 
-        private void ValidateAssertionExpiration(XmlNode assertionElement)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="assertionElement"></param>
+        /// <param name="clockTolerance">Allow for clock slip of this amount (on top of what the IDP already includes in the NotOnOrAfter assertion)</param>
+        private void ValidateAssertionExpiration(XmlNode assertionElement, TimeSpan? clockTolerance = null)
         {
             var subjectElement = assertionElement[Saml2Constants.Message.Subject, Saml2Constants.AssertionNamespace.OriginalString];
             if(subjectElement == null)
@@ -117,7 +122,14 @@ namespace ITfoxtec.Saml2
             }
 
             var notOnOrAfter = DateTime.Parse(subjectConfirmationData.Attributes[Saml2Constants.Message.NotOnOrAfter].GetValueOrNull(), CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
-            if(notOnOrAfter < DateTime.UtcNow)
+            var now = DateTime.UtcNow;
+
+            if (clockTolerance.HasValue)
+            {
+                now += clockTolerance.Value;
+            }
+
+            if (notOnOrAfter < now)
             {
                 throw new Saml2ResponseException(string.Format("Assertion has expired. Assertion valid NotOnOrAfter {0}.", notOnOrAfter));
             }

--- a/ITfoxtec.Saml2/Saml2AuthnResponse.cs
+++ b/ITfoxtec.Saml2/Saml2AuthnResponse.cs
@@ -74,14 +74,14 @@ namespace ITfoxtec.Saml2
             throw new NotImplementedException();
         }
 
-        internal override void Read(string xml, bool validateXmlSignature = false)
+        internal override void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
             base.Read(xml, validateXmlSignature);
 
             if (Status == Saml2StatusCodes.Success)
             {
                 var assertionElement = GetAssertionElement();
-                ValidateAssertionExpiration(assertionElement);
+                ValidateAssertionExpiration(assertionElement, clockTolerance: clockTolerance);
 
                 Saml2SecurityToken = ReadSecurityToken(assertionElement);
                 ClaimsIdentity = ReadClaimsIdentity();

--- a/ITfoxtec.Saml2/Saml2IdPInitiatedAuthnResponse.cs
+++ b/ITfoxtec.Saml2/Saml2IdPInitiatedAuthnResponse.cs
@@ -77,7 +77,7 @@ namespace ITfoxtec.Saml2
             return XmlDocument;
         }
 
-        internal override void Read(string xml, bool validateXmlSignature = false)
+        internal override void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
             throw new NotImplementedException();
         }

--- a/ITfoxtec.Saml2/Saml2Request.cs
+++ b/ITfoxtec.Saml2/Saml2Request.cs
@@ -136,7 +136,7 @@ namespace ITfoxtec.Saml2
             return result;
         }
 
-        internal virtual void Read(string xml, bool validateXmlSignature = false)
+        internal virtual void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
 #if DEBUG
             Debug.WriteLine("Saml2P: " + xml);

--- a/ITfoxtec.Saml2/Saml2Response.cs
+++ b/ITfoxtec.Saml2/Saml2Response.cs
@@ -40,7 +40,7 @@ namespace ITfoxtec.Saml2
                     new XAttribute(Saml2Constants.Message.Value, Saml2StatusCodeUtil.ToString(Status))));
         }
 
-        internal override void Read(string xml, bool validateXmlSignature = false)
+        internal override void Read(string xml, bool validateXmlSignature = false, TimeSpan? clockTolerance = null)
         {
             base.Read(xml, validateXmlSignature);
 


### PR DESCRIPTION
Hi there,
We have some challenging government clients that are not inclined to make changes at the Identity Provider end to clock tolerance, so have provided the ability to add an additional tolerance to NotOnOrAfter checks.

I am not sure if this is the 'best' way but I thought it easier to illustrate my suggestion.

We have done this is in the past with a home-grown SAML2 implementation, but would prefer to use your lovely solution instead.

Comments and criticism welcome,

Thanks heaps, 
Stuart